### PR TITLE
Don't include domain in generated urls

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -38,7 +38,7 @@ jobs:
         # will obviously return error 404 not found.
         run: ./trunk build --release --public-url $public_url
         env:
-          public_url: "https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}"
+          public_url: "/${{ github.event.repository.name }}"
       - name: Deploy
         uses: JamesIves/github-pages-deploy-action@v4
         with:


### PR DESCRIPTION
This makes the project more compatible with being hosted on `hypercubing.xyz`, since it will directly use the resources hosted on `hypercubing.xyz` instead of `henrydukepickle.github.io`.